### PR TITLE
解决了阿里云OSS文件上传中访问的url为https://xxx.xxx.com:80的问题

### DIFF
--- a/SourceCode/server/components/oss-utils/oss-utils.js
+++ b/SourceCode/server/components/oss-utils/oss-utils.js
@@ -32,6 +32,7 @@ const getTempSTS = async function(session) {
     var token = await sts.assumeRole(roleArn, policy, 3600, session)
     token.credentials.region = conf.ossConf.region
     token.credentials.bucket = conf.ossConf.bucket
+    token.credentials.secure = conf.ossConf.secure
 
     return token.credentials
 }
@@ -64,6 +65,7 @@ const ossUpDate = async function(session) {
     var token = await sts.assumeRole(roleArn, policy, 3600, session)
     token.credentials.region = conf.ossConf.region
     token.credentials.bucket = conf.ossConf.bucket
+    token.credentials.secure = conf.ossConf.secure
 
     return token.credentials
 }

--- a/SourceCode/site/activity-react/template.html
+++ b/SourceCode/site/activity-react/template.html
@@ -8,7 +8,7 @@
         <meta name="keyword" content="">
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.26.0/polyfill.js"></script><!--ignore-->
         <script type="text/javascript" src="//gosspublic.alicdn.com/aliyun-oss-sdk-4.4.4.min.js"></script><!--ignore-->
-        <script src="http://g.tbcdn.cn/mtb/lib-flexible/0.3.2/??flexible_css.js,flexible.js"></script><!--ignore-->
+        <script src="https://cdn.jsdelivr.net/npm/lib-flexible@0.3.2/flexible.min.js"></script><!--ignore-->
         <script src="https://res.wx.qq.com/connect/zh_CN/htmledition/js/wxLogin.js"></script><!--ignore-->
     </head>
     <body style="background: #fffaf2">

--- a/SourceCode/site/activity-react/utils/file-uploader.js
+++ b/SourceCode/site/activity-react/utils/file-uploader.js
@@ -75,7 +75,7 @@ const getOssClient = async () => {
     const client = new OSSW({
         region: token.region,
         accessKeyId: token.AccessKeyId,
-        secure: false,
+        secure: true,
         accessKeySecret: token.AccessKeySecret,
         stsToken: token.SecurityToken,
         bucket: token.bucket,


### PR DESCRIPTION
具体的修改是在config文件的ossConfig字段中增加了secure参数，并在oss-util.js、file-uploader.js中增加了secure=true的参数。另外，将template.html中flexble.js的引用url更换为了https的地址，以适配https部署的外部链接url的要求。